### PR TITLE
Pinned jax version in pyrproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ description = "GPU accelerated implementations of common RC architectures"
 readme = "README.md"
 dynamic = ["version"]
 dependencies = [
-    "jax",
+    "jax==0.6.0",
     "equinox",
     "matplotlib",
     "setuptools_scm>=8.1",
@@ -72,7 +72,7 @@ convention = "numpy"
 
 [project.optional-dependencies]
 all = [
-    "jax[cuda12]",
+    "jax[cuda12]==0.6.0",
     "ruff",
     "pytest",
     "coverage",
@@ -83,4 +83,4 @@ all = [
 ]
 dev = ["ruff", "pytest", "coverage", "pytest-cov", "pytest-env"]
 notebooks = ["notebook", "ipykernel"]
-gpu = ["jax[cuda12]"]
+gpu = ["jax[cuda12]==0.6.0"]

--- a/tests/models/test_esn.py
+++ b/tests/models/test_esn.py
@@ -283,7 +283,7 @@ def test_forecast_from_IC_CESN(dummy_problem_params):
         initial_res_state=jax.numpy.zeros((chunks, res_dim), dtype=jnp.float64),
     )
     U_pred1 = esn.forecast(ts=ts_test, res_state=R[-1])
-    U_pred2 = esn.forecast_from_IC(ts=ts_test, spinup_data=U_train[-400:])
+    U_pred2 = esn.forecast_from_IC(ts=ts_test, spinup_data=U_train)
     assert jnp.allclose(U_pred1, U_pred2, atol=1e-2)
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Jax 0.6.1 (which was released today) broke the solver used in `train_ESNForecaster.` Pinning version in pyproject.toml to 0.6.0 for now. 

Ran all tests on both cpu and gpu installations. Slightly modified CESN forecast from IC test since the GPU random instantiation of reservoir had too long of a synchronization period. 