### PR TITLE
Serial instantiation training

### DIFF
--- a/src/orc/drivers.py
+++ b/src/orc/drivers.py
@@ -163,6 +163,7 @@ class ESNDriver(DriverBase):
         *,
         seed: int,
         use_sparse_eigs: bool = True,
+        eigenval_batch_size: int = None,
     ) -> None:
         """Initialize weight matrices.
 
@@ -192,6 +193,9 @@ class ESNDriver(DriverBase):
             Whether to use sparse eigensolver for setting the spectral radius of wr.
             Default is True, which is recommended to save memory and compute time. If
             False, will use dense eigensolver which may be more accurate.
+        eigenval_batch_size : int
+            Size of batches when batch_eigenvals. Default is None, which means no
+            batch eigenvalue computation.
         """
         super().__init__(res_dim=res_dim, dtype=dtype)
         self.res_dim = res_dim
@@ -233,11 +237,33 @@ class ESNDriver(DriverBase):
             dtype=dtype,
             generator=jax.random.normal,
         )
-        if use_sparse_eigs:
-            eigs = jnp.abs(jax.vmap(max_eig_arnoldi)(sp_mat))
+
+        # Compute eigenvalues - batch if requested to avoid memory issues
+        if eigenval_batch_size is not None:
+            batch_size = min(eigenval_batch_size, chunks)
+            eigs_list = []
+
+            for i in range(0, chunks, batch_size):
+                end_idx = min(i + batch_size, chunks)
+                batch_sp_mat = sp_mat[i:end_idx]
+
+                if use_sparse_eigs:
+                    batch_eigs = jnp.abs(jax.vmap(max_eig_arnoldi)(batch_sp_mat))
+                else:
+                    batch_dense_mat = sparse.bcoo_todense(batch_sp_mat)
+                    batch_eigs = jnp.max(
+                        jnp.abs(jnp.linalg.eigvals(batch_dense_mat)), axis=1
+                    )
+
+                eigs_list.append(batch_eigs)
+
+            eigs = jnp.concatenate(eigs_list, axis=0)
         else:
-            dense_mat = sparse.bcoo_todense(sp_mat)
-            eigs = jnp.max(jnp.abs(jnp.linalg.eigvals(dense_mat)), axis=1)
+            if use_sparse_eigs:
+                eigs = jnp.abs(jax.vmap(max_eig_arnoldi)(sp_mat))
+            else:
+                dense_mat = sparse.bcoo_todense(sp_mat)
+                eigs = jnp.max(jnp.abs(jnp.linalg.eigvals(dense_mat)), axis=1)
         self.wr = spectral_radius * (sp_mat / eigs[:, None, None])
         self.chunks = chunks
         self.dtype = dtype

--- a/src/orc/models/esn.py
+++ b/src/orc/models/esn.py
@@ -295,8 +295,50 @@ class CESNForecaster(CRCForecasterBase):
         )
         self.chunks = chunks
 
-# vmap ridge regression solver for parallel RC cases
 _solve_all_ridge_reg = eqx.filter_vmap(ridge_regression, in_axes=eqx.if_array(1))
+
+
+def _solve_all_ridge_reg_batched(
+    res_seq_train: Array, target_seq: Array, beta: float, batch_size: int
+) -> Array:
+    """Solve ridge regression for all parallel reservoirs using batched vmap.
+
+    This function processes the parallel reservoirs in batches to reduce memory
+    usage for large numbers of parallel reservoirs.
+
+    Parameters
+    ----------
+    res_seq_train : Array
+        Training reservoir states, shape=(seq_len, chunks, res_dim).
+    target_seq : Array
+        Target sequence, shape=(seq_len, chunks, out_dim).
+    beta : float
+        Tikhonov regularization parameter.
+    batch_size : int
+        Number of parallel reservoirs to process in each batch.
+
+    Returns
+    -------
+    Array
+        Ridge regression solution for all chunks, shape=(chunks, out_dim, res_dim).
+    """
+    chunks = res_seq_train.shape[1]
+
+    if batch_size >= chunks:
+        return _solve_all_ridge_reg(res_seq_train, target_seq, beta)
+
+    results = []
+    for i in range(0, chunks, batch_size):
+        end_idx = min(i + batch_size, chunks)
+        batch_res = res_seq_train[:, i:end_idx, :]
+        batch_target = target_seq[:, i:end_idx, :]
+
+        batch_vmap = eqx.filter_vmap(ridge_regression, in_axes=eqx.if_array(1))
+        batch_result = batch_vmap(batch_res, batch_target, beta)
+        results.append(batch_result)
+
+    return jnp.concatenate(results, axis=0)
+
 
 def train_ESNForecaster(
     model: ESNForecaster,
@@ -305,6 +347,7 @@ def train_ESNForecaster(
     spinup: int = 0,
     initial_res_state: Array = None,
     beta: float = 8e-8,
+    batch_size: int = None,
 ) -> tuple[ESNForecaster, Array]:
     """Training function for ESNForecaster.
 
@@ -322,6 +365,10 @@ def train_ESNForecaster(
         Initial transient of reservoir states to discard.
     beta : float
         Tikhonov regularization parameter.
+    batch_size : int, optional
+        Number of parallel reservoirs to process in each batch for ridge regression.
+        If None (default), processes all reservoirs at once. Use smaller values
+        to reduce memory usage for large numbers of parallel reservoirs.
 
     Returns
     -------
@@ -355,7 +402,6 @@ def train_ESNForecaster(
     else:
         tot_seq = jnp.vstack((train_seq, target_seq[-1:]))
 
-
     tot_res_seq = model.force(tot_seq, initial_res_state)
     res_seq = tot_res_seq[:-1]
     if isinstance(model.readout, NonlinearReadout):
@@ -363,11 +409,23 @@ def train_ESNForecaster(
     else:
         res_seq_train = res_seq
 
-    cmat = _solve_all_ridge_reg(
-        res_seq_train[spinup:],
-        target_seq[spinup:].reshape(res_seq[spinup:].shape[0], res_seq.shape[1], -1),
-        beta,
-    )
+    if batch_size is None:
+        cmat = _solve_all_ridge_reg(
+            res_seq_train[spinup:],
+            target_seq[spinup:].reshape(
+                res_seq[spinup:].shape[0], res_seq.shape[1], -1
+            ),
+            beta,
+        )
+    else:
+        cmat = _solve_all_ridge_reg_batched(
+            res_seq_train[spinup:],
+            target_seq[spinup:].reshape(
+                res_seq[spinup:].shape[0], res_seq.shape[1], -1
+            ),
+            beta,
+            batch_size,
+        )
 
     def where(m):
         return m.readout.wout
@@ -385,6 +443,7 @@ def train_CESNForecaster(
     spinup: int = 0,
     initial_res_state: Array = None,
     beta: float = 8e-8,
+    batch_size: int = None,
 ) -> tuple[CESNForecaster, Array]:
     """Training function for CESNForecaster.
 
@@ -404,6 +463,10 @@ def train_CESNForecaster(
         Initial transient of reservoir states to discard.
     beta : float
         Tikhonov regularization parameter.
+    batch_size : int, optional
+        Number of parallel reservoirs to process in each batch for ridge regression.
+        If None (default), processes all reservoirs at once. Use smaller values
+        to reduce memory usage for large numbers of parallel reservoirs.
 
     Returns
     -------
@@ -449,11 +512,23 @@ def train_CESNForecaster(
     else:
         res_seq_train = res_seq
 
-    cmat = _solve_all_ridge_reg(
-        res_seq_train[spinup:],
-        target_seq[spinup:].reshape(res_seq[spinup:].shape[0], res_seq.shape[1], -1),
-        beta,
-    )
+    if batch_size is None:
+        cmat = _solve_all_ridge_reg(
+            res_seq_train[spinup:],
+            target_seq[spinup:].reshape(
+                res_seq[spinup:].shape[0], res_seq.shape[1], -1
+            ),
+            beta,
+        )
+    else:
+        cmat = _solve_all_ridge_reg_batched(
+            res_seq_train[spinup:],
+            target_seq[spinup:].reshape(
+                res_seq[spinup:].shape[0], res_seq.shape[1], -1
+            ),
+            beta,
+            batch_size,
+        )
 
     def where(m):
         return m.readout.wout

--- a/tests/models/test_esn.py
+++ b/tests/models/test_esn.py
@@ -12,12 +12,13 @@ import orc.data
 def dummy_problem_params():
     """Set up dummy data for testing parallel ESNs."""
     Nx = 64
-    dummy_data = jnp.repeat(jnp.sin(jnp.arange(Nx)).reshape(1,-1), 1000, axis=0)
+    dummy_data = jnp.repeat(jnp.sin(jnp.arange(Nx)).reshape(1, -1), 1000, axis=0)
     key = jax.random.key(0)
     # some noise increases robustness of ESN forecast
-    U_train = dummy_data + jax.random.normal(key=key, shape=(1000,Nx)) * 0.02
+    U_train = dummy_data + jax.random.normal(key=key, shape=(1000, Nx)) * 0.02
     U_test = dummy_data
     return Nx, U_train, U_test
+
 
 ####################### ESN TESTS #####################
 def test_esn_train():
@@ -79,8 +80,9 @@ def test_periodic_par_esn(dummy_problem_params):
     U_pred = esn.forecast(fcast_len=fcast_len, res_state=R[-1])
     assert (jnp.linalg.norm(U_pred - U_test[:fcast_len, :]) / fcast_len) < 1e-2
 
+
 def test_nonperiodic_par_esn(dummy_problem_params):
-    """Test nonperiodic parallel ESN on dummy problem. """
+    """Test nonperiodic parallel ESN on dummy problem."""
     # test params
     res_dim = 300
     chunks = 32
@@ -111,6 +113,7 @@ def test_nonperiodic_par_esn(dummy_problem_params):
     U_pred = esn.forecast(fcast_len=fcast_len, res_state=R[-1])
     assert (jnp.linalg.norm(U_pred - U_test[:fcast_len, :]) / fcast_len) < 1e-2
 
+
 def test_forecast_from_IC(dummy_problem_params):
     """Test forecast from IC vs forecast from reservoir state."""
     res_dim = 100
@@ -140,8 +143,8 @@ def test_forecast_from_IC(dummy_problem_params):
     assert jnp.allclose(U_pred1, U_pred2)
 
 
-
 ###################### CESN TESTS #####################
+
 
 def test_cesn_train():
     """
@@ -164,10 +167,14 @@ def test_cesn_train():
 
     # train cesn
     solver = diffrax.Euler()
-    stepsize_controller = diffrax.ConstantStepSize() # faster for testing
-    cesn = orc.models.CESNForecaster(data_dim=3, res_dim=res_dim, seed=0,
-                                     stepsize_controller=stepsize_controller,
-                                     solver=solver)
+    stepsize_controller = diffrax.ConstantStepSize()  # faster for testing
+    cesn = orc.models.CESNForecaster(
+        data_dim=3,
+        res_dim=res_dim,
+        seed=0,
+        stepsize_controller=stepsize_controller,
+        solver=solver,
+    )
     cesn, R = orc.models.esn.train_CESNForecaster(cesn, U_train, ts_train)
 
     # forecast
@@ -198,7 +205,7 @@ def test_periodic_par_cesn(dummy_problem_params):
         chunks=chunks,
         locality=locality,
         periodic=True,
-        time_const = 25.0,
+        time_const=25.0,
     )
 
     # train cesn
@@ -236,7 +243,7 @@ def test_nonperiodic_par_cesn(dummy_problem_params):
         chunks=chunks,
         locality=locality,
         periodic=False,
-        time_const = 25.0,
+        time_const=25.0,
     )
 
     # train cesn
@@ -251,6 +258,7 @@ def test_nonperiodic_par_cesn(dummy_problem_params):
     U_pred = cesn.forecast(ts=ts_test, res_state=R[-1])
     assert (jnp.linalg.norm(U_pred - U_test[:fcast_len, :]) / fcast_len) < 1e-2
 
+
 def test_forecast_from_IC_CESN(dummy_problem_params):
     """Test forecast from IC vs forecast from reservoir state."""
     res_dim = 100
@@ -262,8 +270,9 @@ def test_forecast_from_IC_CESN(dummy_problem_params):
     Nx, U_train, U_test = dummy_problem_params
     ts_train = jnp.linspace(0, 10, U_train.shape[0])
     dt = ts_train[1] - ts_train[0]
-    ts_test = jnp.arange(0, fcast_len, dtype=jnp.float64
-                         ) * dt  # Time values for testing
+    ts_test = (
+        jnp.arange(0, fcast_len, dtype=jnp.float64) * dt
+    )  # Time values for testing
 
     esn = orc.models.CESNForecaster(
         data_dim=Nx,
@@ -272,8 +281,8 @@ def test_forecast_from_IC_CESN(dummy_problem_params):
         chunks=chunks,
         locality=locality,
         periodic=False,
-        time_const = 20.0,
-        quadratic=True
+        time_const=20.0,
+        quadratic=True,
     )
 
     esn, R = orc.models.esn.train_CESNForecaster(
@@ -286,13 +295,15 @@ def test_forecast_from_IC_CESN(dummy_problem_params):
     U_pred2 = esn.forecast_from_IC(ts=ts_test, spinup_data=U_train)
     assert jnp.allclose(U_pred1, U_pred2, atol=1e-2)
 
+
 @pytest.mark.parametrize(
     "solver, controller",
     [
         (diffrax.Euler(), diffrax.ConstantStepSize()),
         (diffrax.Tsit5(), diffrax.PIDController(rtol=1e-3, atol=1e-6)),
         (diffrax.Dopri8(), diffrax.PIDController(rtol=1e-4, atol=1e-7)),
-    ])
+    ],
+)
 def test_cesn_different_solvers(solver, controller):
     """Test CESN with different diffrax solvers and controllers."""
     res_dim = 200
@@ -316,16 +327,11 @@ def test_cesn_different_solvers(solver, controller):
         res_dim=res_dim,
         seed=0,
         solver=solver,
-        stepsize_controller=controller
+        stepsize_controller=controller,
     )
 
     # Train the model
-    cesn, R = orc.models.esn.train_CESNForecaster(
-        cesn,
-        U_train,
-        ts_train,
-        beta=1e-6
-    )
+    cesn, R = orc.models.esn.train_CESNForecaster(cesn, U_train, ts_train, beta=1e-6)
 
     # Test forecasting ability
     U_pred = cesn.forecast(ts=ts_test, res_state=R[-1])
@@ -333,3 +339,92 @@ def test_cesn_different_solvers(solver, controller):
     # Ensure output is well-formed (finitely valued, correct shape)
     assert U_pred.shape == (fcast_len, data_dim)
     assert jnp.all(jnp.isfinite(U_pred))
+
+def test_esn_batched_vmap_equivalence(dummy_problem_params):
+    """Test that batched vmap produces identical results to non-batched vmap."""
+    Nx, U_train, U_test = dummy_problem_params
+
+    # Use parallel ESN with multiple chunks to test batching
+    chunks = 8
+    res_dim = 500
+
+    # Create ESN model
+    esn = orc.models.ESNForecaster(data_dim=Nx, res_dim=res_dim, chunks=chunks, seed=42)
+
+    # Train without batching (default)
+    esn_unbatched, R_unbatched = orc.models.esn.train_ESNForecaster(
+        esn, U_train[:100], batch_size=None
+    )
+
+    # Train with batching
+    esn_batched, R_batched = orc.models.esn.train_ESNForecaster(
+        esn, U_train[:100], batch_size=4
+    )
+
+    # Results should be identical
+    assert jnp.allclose(
+        esn_unbatched.readout.wout, esn_batched.readout.wout, atol=1e-12
+    )
+    assert jnp.allclose(R_unbatched, R_batched, atol=1e-12)
+
+
+def test_cesn_batched_vmap_equivalence(dummy_problem_params):
+    """Test that batched vmap produces same results as non-batched vmap for CESN."""
+    Nx, U_train, U_test = dummy_problem_params
+
+    # Use parallel CESN with multiple chunks to test batching
+    chunks = 8
+    res_dim = 500
+    dt = 0.01
+    t_train = jnp.arange(100) * dt
+
+    # Create CESN model
+    cesn = orc.models.CESNForecaster(
+        data_dim=Nx, res_dim=res_dim, chunks=chunks, seed=42
+    )
+
+    # Train without batching (default)
+    cesn_unbatched, R_unbatched = orc.models.esn.train_CESNForecaster(
+        cesn, U_train[:100], t_train, batch_size=None
+    )
+
+    # Train with batching
+    cesn_batched, R_batched = orc.models.esn.train_CESNForecaster(
+        cesn, U_train[:100], t_train, batch_size=3
+    )
+
+    # Results should be identical
+    assert jnp.allclose(
+        cesn_unbatched.readout.wout, cesn_batched.readout.wout, atol=1e-12
+    )
+    assert jnp.allclose(R_unbatched, R_batched, atol=1e-12)
+
+
+def test_batched_vmap_different_batch_sizes():
+    """Test that different batch sizes produce identical results."""
+    # Create test data
+    Nx = 32
+    chunks = 4
+    res_dim = 500
+    dummy_data = jnp.repeat(jnp.sin(jnp.arange(Nx)).reshape(1, -1), 50, axis=0)
+
+    # Create ESN model
+    esn = orc.models.ESNForecaster(
+        data_dim=Nx, res_dim=res_dim, chunks=chunks, seed=123
+    )
+
+    # Train with different batch sizes
+    results = []
+    batch_sizes = [None,1, 2, 4, 6]  # Include batch_size > chunks
+
+    for batch_size in batch_sizes:
+        esn_trained, _ = orc.models.esn.train_ESNForecaster(
+            esn, dummy_data, batch_size=batch_size
+        )
+        results.append(esn_trained.readout.wout)
+
+    # All results should be identical
+    for i in range(1, len(results)):
+        assert jnp.allclose(results[0], results[i], atol=1e-12), (
+            f"Batch size {batch_sizes[i]} produced different results"
+        )


### PR DESCRIPTION
Added options to batch the training and instantiation of parallel reservoirs. Default behavior remains the same. We had discussed using pmap to do this, but ended up going with the approach here because pmap assumes multiple devices.