### PR TITLE
Allowed for python 3.13 and removed unnecessary JAX pin

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
   run-tests:
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12","3.13"]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,14 +24,14 @@ description = "GPU accelerated implementations of common RC architectures"
 readme = "README.md"
 dynamic = ["version"]
 dependencies = [
-    "jax==0.6.0",
+    "jax",
     "equinox",
     "matplotlib",
     "setuptools_scm>=8.1",
     "diffrax",
 ]
 
-requires-python = ">=3.10, <3.13"
+requires-python = ">=3.10, <3.14"
 keywords = ["reservoir computing", ""]
 classifiers = [
     "License :: OSI Approved :: BSD License",
@@ -39,6 +39,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Data Science",
 ]
 
@@ -72,7 +73,7 @@ convention = "numpy"
 
 [project.optional-dependencies]
 all = [
-    "jax[cuda12]==0.6.0",
+    "jax[cuda12]",
     "ruff",
     "pytest",
     "coverage",
@@ -98,7 +99,7 @@ dev = [
     "mkdocstrings[python]",
 ]
 notebooks = ["notebook", "ipykernel"]
-gpu = ["jax[cuda12]==0.6.0"]
+gpu = ["jax[cuda12]"]
 docs = [
     "mkdocs",
     "mkdocs-material",
@@ -106,3 +107,4 @@ docs = [
     "mkdocstrings[python]",
     "mkdocs-jupyter",
 ]
+


### PR DESCRIPTION
In the title. JAX version had been pinned and fixed python to 3.12 long time ago because of bug with JAX. Bug been fixed and we need to test 3.13, especially with 3.14 now out. 