### PR TITLE
Ensemble

### DIFF
--- a/src/orc/embeddings.py
+++ b/src/orc/embeddings.py
@@ -423,7 +423,6 @@ class EnsembleLinearEmbedding(EmbedBase):
     dtype: Float
     chunks: int
 
-
     def __init__(
         self,
         in_dim: int,
@@ -463,7 +462,6 @@ class EnsembleLinearEmbedding(EmbedBase):
         )
         self.chunks = chunks
 
-
     @eqx.filter_jit
     def embed(self, in_state: Array) -> Array:
         """Embed single state to reservoir dimensions.
@@ -480,7 +478,6 @@ class EnsembleLinearEmbedding(EmbedBase):
         """
         if in_state.shape != (self.in_dim,):
             raise ValueError("Incorrect dimension for input state.")
-
 
         return self.win @ in_state
 

--- a/src/orc/models/__init__.py
+++ b/src/orc/models/__init__.py
@@ -3,8 +3,10 @@
 from orc.models import esn
 from orc.models.esn import (
     CESNForecaster,
+    EnsembleESNForecaster,
     ESNForecaster,
     train_CESNForecaster,
+    train_EnsembleESNForecaster,
     train_ESNForecaster,
 )
 
@@ -14,4 +16,6 @@ __all__ = [
     "CESNForecaster",
     "train_ESNForecaster",
     "train_CESNForecaster",
+    "train_EnsembleESNForecaster",
+    "EnsembleESNForecaster",
 ]

--- a/src/orc/models/esn.py
+++ b/src/orc/models/esn.py
@@ -304,7 +304,6 @@ class CESNForecaster(CRCForecasterBase):
         self.chunks = chunks
 
 
-# TODO: EnsembleESNForecaster
 class EnsembleESNForecaster(RCForecasterBase):
     """
     Ensembled ESNs for forecasting.

--- a/src/orc/readouts.py
+++ b/src/orc/readouts.py
@@ -691,3 +691,110 @@ class QuadraticReadout(NonlinearReadout):
             dtype=dtype,
             nonlin_list=[lambda x: x**2],
         )
+
+
+class EnsembleLinearReadout(ReadoutBase):
+    """Esembled linear readout layer.
+
+    Attributes
+    ----------
+    out_dim : int
+        Dimension of reservoir output.
+    res_dim : int
+        Reservoir dimension.
+    chunks : int
+        Number of parallel reservoirs.
+    wout : Array
+        Output matrix.
+    dtype : Float
+            Dtype, default jnp.float64.
+
+    Methods
+    -------
+    readout(res_state)
+        Map from reservoir state to output state.
+    """
+
+    out_dim: int
+    res_dim: int
+    wout: Array
+    chunks: int
+    dtype: Float
+
+    def __init__(
+        self,
+        out_dim: int,
+        res_dim: int,
+        chunks: int = 5,
+        dtype: Float = jnp.float64,
+        *,
+        seed: int = 0,
+    ) -> None:
+        """Initialize readout layer to zeros.
+
+        Parameters
+        ----------
+        out_dim : int
+            Dimension of reservoir output.
+        res_dim : int
+            Reservoir dimension.
+        chunks : int
+            Number of parallel resrevoirs.
+        dtype : Float
+            Dtype, default jnp.float64.
+        seed : int
+            Not used for ParallelLinearReadout, here to maintain consistent
+            interface.
+        """
+        super().__init__(out_dim=out_dim, res_dim=res_dim, dtype=dtype)
+        self.out_dim = out_dim
+        self.res_dim = res_dim
+        self.wout = jnp.zeros((chunks, out_dim, res_dim), dtype=dtype)
+        self.dtype = dtype
+        self.chunks = chunks
+
+    @eqx.filter_jit
+    def readout(self, res_state: Array) -> Array:
+        """Readout from reservoir state.
+
+        Parameters
+        ----------
+        res_state : Array
+            Reservoir state, (shape=(chunks, res_dim,)).
+
+        Returns
+        -------
+        Array
+            Output from reservoir, (shape=(out_dim,)).
+        """
+        if res_state.shape[1] != self.res_dim:
+            raise ValueError(
+                "Incorrect reservoir dimension for instantiated output map."
+            )
+        return jnp.mean(eqx.filter_vmap(jnp.matmul)(self.wout, res_state), axis=0)
+
+    @eqx.filter_jit
+    def __call__(self, res_state: Array) -> Array:
+        """Call either readout or batch_readout depending on dimensions.
+
+        Parameters
+        ----------
+        res_state : Array
+            Reservoir state, (shape=(chunks, res_dim) or
+            shape=(seq_len, chunks, res_dim)).
+
+        Returns
+        -------
+        Array
+            Output state, (out_dim,) or shape=(seq_len, out_dim)).
+        """
+        if len(res_state.shape) == 2:
+            to_ret = self.readout(res_state)
+        elif len(res_state.shape) == 3:
+            to_ret = self.batch_readout(res_state)
+        else:
+            raise ValueError(
+                "Only 1-dimensional localization is currently supported, detected a "
+                f"{len(res_state.shape)}D field."
+            )
+        return to_ret

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -146,6 +146,6 @@ def test_ensemble_embed_shapes(chunks, batch_size, in_dim):
     outputs = embedding(inputs)
     assert outputs.shape == (batch_size, chunks, res_dim)
 
-    inputs = jnp.ones((in_dim))
+    inputs = jnp.ones(in_dim)
     outputs = embedding(inputs)
     assert outputs.shape == (chunks, res_dim)

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -122,3 +122,30 @@ def test_single_linearembedding_call(single_linearembedding):
 def test_single_linearembedding_chunks_is_one(single_linearembedding):
     """Test that LinearEmbedding always has chunks=1."""
     assert single_linearembedding.chunks == 1
+
+
+##################### ENSEMBLE LINEAR EMBEDDING TESTS #####################
+
+
+@pytest.mark.parametrize(
+    "chunks,batch_size,in_dim",
+    [
+        (5, 32, 3),
+        (3, 16, 4),
+        (15, 17, 5),
+    ],
+)
+def test_ensemble_embed_shapes(chunks, batch_size, in_dim):
+    res_dim = 312
+    in_dim = 5
+    scaling = 0.084
+    embedding = orc.embeddings.EnsembleLinearEmbedding(
+        in_dim, res_dim, scaling, chunks, seed=0
+    )
+    inputs = jnp.ones((batch_size, in_dim))
+    outputs = embedding(inputs)
+    assert outputs.shape == (batch_size, chunks, res_dim)
+
+    inputs = jnp.ones((in_dim))
+    outputs = embedding(inputs)
+    assert outputs.shape == (chunks, res_dim)

--- a/tests/test_readouts.py
+++ b/tests/test_readouts.py
@@ -269,3 +269,30 @@ def test_single_quadraticreadout_call(single_quadraticreadout):
 def test_single_quadraticreadout_chunks_is_one(single_quadraticreadout):
     """Test that QuadraticReadout always has chunks=1."""
     assert single_quadraticreadout.chunks == 1
+
+
+##################### ENSEMBLE LINEAR READOUT TESTS #####################
+
+
+@pytest.mark.parametrize(
+    "chunks,batch_size,out_dim",
+    [
+        (5, 32, 3),
+        (3, 16, 4),
+        (15, 17, 5),
+    ],
+)
+def test_ensemble_readout_shapes(chunks, batch_size, out_dim):
+    res_dim = 747
+    readout = orc.readouts.EnsembleLinearReadout(out_dim, res_dim, chunks)
+
+    inputs = jnp.ones((batch_size, chunks, res_dim))
+    outputs = readout(inputs)
+    assert outputs.shape == (
+        batch_size,
+        out_dim,
+    )
+
+    inputs = jnp.ones((chunks, res_dim))
+    outputs = readout(inputs)
+    assert outputs.shape == (out_dim,)


### PR DESCRIPTION
Added EnsembleLinearEmbedding and EnsembleLinearReadout with associated tests. The new EnsembleESNForecaster uses both of these layers and the standard ESNDriver. There's a lot of reused code for training each of the different models. Should be a priority to implement a more unified training function, but functionality/tests are there now. Waiting on GPU tests to finish running then will merge.