### PR TITLE
Restructure call

### DIFF
--- a/src/orc/embeddings.py
+++ b/src/orc/embeddings.py
@@ -107,11 +107,6 @@ class EmbedBase(eqx.Module, ABC):
             to_ret = self.embed(in_state)
         elif len(in_state.shape) == 2:
             to_ret = self.batch_embed(in_state)
-        else:
-            raise ValueError(
-                "Only 1-dimensional localization is currently supported, detected a "
-                f"{len(in_state.shape) - 1}D field."
-            )
         return to_ret
 
 

--- a/src/orc/rc.py
+++ b/src/orc/rc.py
@@ -201,7 +201,9 @@ class RCForecasterBase(eqx.Module, ABC):
         """
 
         def scan_fn(state, _):
-            out_state = self.driver.advance(self.embedding.embed(self.readout.readout(state)), state)
+            out_state = self.driver.advance(
+                self.embedding.embed(self.readout.readout(state)), state
+            )
             return (out_state, self.readout.readout(out_state))
 
         _, state_seq = jax.lax.scan(scan_fn, res_state, None, length=fcast_len - 1)
@@ -419,7 +421,9 @@ class CRCForecasterBase(RCForecasterBase, ABC):
         # RC autonomous ODE definition
         @eqx.filter_jit
         def res_ode(t, r, args):
-            out_state = self.driver.advance(self.embedding.embed(self.readout.readout(r)), r)
+            out_state = self.driver.advance(
+                self.embedding.embed(self.readout.readout(r)), r
+            )
             return out_state
 
         # integrate RC

--- a/src/orc/readouts.py
+++ b/src/orc/readouts.py
@@ -87,22 +87,30 @@ class ReadoutBase(eqx.Module, ABC):
         self,
         res_state: Array,
     ) -> Array:
-        """Readout from reservoir state.
-
-        If readout supports parallel reservoirs, this method needs to be overwritten
-        to accomodate shape handling.
+        """Call either readout or batch_readout depending on dimensions.
 
         Parameters
         ----------
         res_state : Array
-            Reservoir state.
+            Reservoir state, (shape=(chunks, res_dim) or
+            shape=(seq_len, chunks, res_dim)).
 
         Returns
         -------
         Array
-            Output from reservoir state.
+            Output state, (out_dim,) or shape=(seq_len, out_dim)).
         """
-        return self.readout(res_state)
+        if self.chunks > 0:
+            if len(res_state.shape) == 2:
+                to_ret = self.readout(res_state)
+            elif len(res_state.shape) == 3:
+                to_ret = self.batch_readout(res_state)
+        else:
+            if len(res_state.shape) == 1:
+                to_ret = self.readout(res_state)
+            elif len(res_state.shape) == 2:
+                to_ret = self.batch_readout(res_state)
+        return to_ret
 
 
 class ParallelLinearReadout(ReadoutBase):
@@ -184,31 +192,6 @@ class ParallelLinearReadout(ReadoutBase):
                 "Incorrect reservoir dimension for instantiated output map."
             )
         return jnp.ravel(eqx.filter_vmap(jnp.matmul)(self.wout, res_state))
-
-    def __call__(self, res_state: Array) -> Array:
-        """Call either readout or batch_readout depending on dimensions.
-
-        Parameters
-        ----------
-        res_state : Array
-            Reservoir state, (shape=(chunks, res_dim) or
-            shape=(seq_len, chunks, res_dim)).
-
-        Returns
-        -------
-        Array
-            Output state, (out_dim,) or shape=(seq_len, out_dim)).
-        """
-        if len(res_state.shape) == 2:
-            to_ret = self.readout(res_state)
-        elif len(res_state.shape) == 3:
-            to_ret = self.batch_readout(res_state)
-        else:
-            raise ValueError(
-                "Only 1-dimensional localization is currently supported, detected a "
-                f"{len(res_state.shape)}D field."
-            )
-        return to_ret
 
 
 class LinearReadout(ParallelLinearReadout):
@@ -418,31 +401,6 @@ class ParallelNonlinearReadout(ReadoutBase):
             )
         transformed_res_state = self.nonlinear_transform(res_state)
         return jnp.ravel(eqx.filter_vmap(jnp.matmul)(self.wout, transformed_res_state))
-
-    def __call__(self, res_state: Array) -> Array:
-        """Call either readout or batch_readout depending on dimensions.
-
-        Parameters
-        ----------
-        res_state : Array
-            Reservoir state, (shape=(chunks, res_dim) or
-            shape=(seq_len, chunks, res_dim)).
-
-        Returns
-        -------
-        Array
-            Output state, (out_dim,) or shape=(seq_len, out_dim)).
-        """
-        if len(res_state.shape) == 2:
-            to_ret = self.readout(res_state)
-        elif len(res_state.shape) == 3:
-            to_ret = self.batch_readout(res_state)
-        else:
-            raise ValueError(
-                "Only 1-dimensional localization is currently supported, detected a "
-                f"{len(res_state.shape)}D field."
-            )
-        return to_ret
 
 
 class NonlinearReadout(ParallelNonlinearReadout):
@@ -773,28 +731,3 @@ class EnsembleLinearReadout(ReadoutBase):
             )
         return jnp.mean(eqx.filter_vmap(jnp.matmul)(self.wout, res_state), axis=0)
 
-    @eqx.filter_jit
-    def __call__(self, res_state: Array) -> Array:
-        """Call either readout or batch_readout depending on dimensions.
-
-        Parameters
-        ----------
-        res_state : Array
-            Reservoir state, (shape=(chunks, res_dim) or
-            shape=(seq_len, chunks, res_dim)).
-
-        Returns
-        -------
-        Array
-            Output state, (out_dim,) or shape=(seq_len, out_dim)).
-        """
-        if len(res_state.shape) == 2:
-            to_ret = self.readout(res_state)
-        elif len(res_state.shape) == 3:
-            to_ret = self.batch_readout(res_state)
-        else:
-            raise ValueError(
-                "Only 1-dimensional localization is currently supported, detected a "
-                f"{len(res_state.shape)}D field."
-            )
-        return to_ret

--- a/src/orc/readouts.py
+++ b/src/orc/readouts.py
@@ -730,4 +730,3 @@ class EnsembleLinearReadout(ReadoutBase):
                 "Incorrect reservoir dimension for instantiated output map."
             )
         return jnp.mean(eqx.filter_vmap(jnp.matmul)(self.wout, res_state), axis=0)
-


### PR DESCRIPTION
Restructured __call__ functions to appear in base layers to avoid having to redefine them all over the place. Also made embed/advance/readout calls explicit in lax scans in rc.py to avoid the if statements I introduced in the __call__ functions.