### PR TITLE
Expand test coverage for jit, vmap, and autodiff

### DIFF
--- a/src/orc/forecaster/base.py
+++ b/src/orc/forecaster/base.py
@@ -277,6 +277,8 @@ class CRCForecasterBase(RCForecasterBase, ABC):
 
     solver: diffrax.AbstractSolver
     stepsize_controller: diffrax.AbstractAdaptiveStepSizeController
+    adjoint: diffrax.AbstractAdjoint
+    max_steps: int = eqx.field(static=True)
 
     def __init__(
         self,
@@ -288,6 +290,8 @@ class CRCForecasterBase(RCForecasterBase, ABC):
         seed: int = 0,
         solver: diffrax.AbstractSolver = None,
         stepsize_controller: diffrax.AbstractAdaptiveStepSizeController = None,
+        adjoint: diffrax.AbstractAdjoint = None,
+        max_steps: int = None,
     ):
         """Initialize the continuous reservoir computer.
 
@@ -309,6 +313,17 @@ class CRCForecasterBase(RCForecasterBase, ABC):
             ODE solver to use for the reservoir computer.
         stepsize_controller : diffrax.AbstractAdaptiveStepSizeController
             Stepsize controller to use for the ODE solver.
+        adjoint : diffrax.AbstractAdjoint
+            Adjoint method passed to ``diffrax.diffeqsolve``. Defaults to
+            ``diffrax.RecursiveCheckpointAdjoint()`` (diffrax's default). Note
+            that reverse-mode autodiff through the solve requires either a
+            finite ``max_steps`` or an adjoint that supports unbounded steps
+            (e.g. ``diffrax.BacksolveAdjoint``).
+        max_steps : int
+            Maximum number of solver steps passed to ``diffrax.diffeqsolve``.
+            Defaults to ``None`` (unbounded), which is fast but not
+            reverse-mode differentiable. Set a finite bound to enable
+            reverse-mode autodiff with the default adjoint.
         """
         super().__init__(driver, readout, embedding, chunks, dtype, seed)
         if solver is None:
@@ -317,8 +332,12 @@ class CRCForecasterBase(RCForecasterBase, ABC):
             stepsize_controller = diffrax.PIDController(
                 rtol=1e-3, atol=1e-6, icoeff=1.0
             )
+        if adjoint is None:
+            adjoint = diffrax.RecursiveCheckpointAdjoint()
         self.solver = solver
         self.stepsize_controller = stepsize_controller
+        self.adjoint = adjoint
+        self.max_steps = max_steps
 
     @eqx.filter_jit
     def force(self, in_seq: Array, res_state: Array, ts: Array) -> Array:
@@ -366,7 +385,8 @@ class CRCForecasterBase(RCForecasterBase, ABC):
             stepsize_controller=self.stepsize_controller,
             args=args,
             saveat=save_at,
-            max_steps=None,
+            adjoint=self.adjoint,
+            max_steps=self.max_steps,
         )
         res_seq = sol.ys
         return res_seq
@@ -429,7 +449,8 @@ class CRCForecasterBase(RCForecasterBase, ABC):
             solver=self.solver,
             stepsize_controller=self.stepsize_controller,
             saveat=save_at,
-            max_steps=None,
+            adjoint=self.adjoint,
+            max_steps=self.max_steps,
         )
         res_seq = sol.ys
         return eqx.filter_vmap(self.readout.readout)(res_seq)

--- a/src/orc/forecaster/models.py
+++ b/src/orc/forecaster/models.py
@@ -203,6 +203,8 @@ class CESNForecaster(CRCForecasterBase):
         use_sparse_eigs: bool = True,
         solver: diffrax.AbstractSolver = None,
         stepsize_controller: diffrax.AbstractAdaptiveStepSizeController = None,
+        adjoint: diffrax.AbstractAdjoint = None,
+        max_steps: int = None,
     ) -> None:
         """
         Initialize the CESN model.
@@ -293,6 +295,8 @@ class CESNForecaster(CRCForecasterBase):
             seed=seed,
             solver=solver,
             stepsize_controller=stepsize_controller,
+            adjoint=adjoint,
+            max_steps=max_steps,
         )
         self.chunks = chunks
 

--- a/tests/classifier/test_classifier_models.py
+++ b/tests/classifier/test_classifier_models.py
@@ -1,3 +1,4 @@
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 import pytest
@@ -281,3 +282,59 @@ def test_train_rcclassifier_quadratic(dummy_classification_data):
     )
 
     assert jnp.allclose(cls_old.readout.wout, cls_new.readout.wout)
+
+
+##################### JAX TRANSFORM & AD TESTS #####################
+
+
+@pytest.fixture
+def esn_classifier():
+    return orc.classifier.ESNClassifier(
+        data_dim=4, n_classes=3, res_dim=200, seed=0
+    )
+
+
+def test_classifier_transform_stability(esn_classifier):
+    """Verify the classifier is compatible with vmap and jit."""
+    model = esn_classifier
+    key = jax.random.key(999)
+    seq_len = 20
+    batch_size = 3
+
+    res_state = model.driver.default_state()
+    batch_seq = jax.random.normal(
+        key, shape=(batch_size, seq_len, model.data_dim)
+    )
+    def fwd(in_seq):
+        return model.classify(in_seq, res_state)
+    vmap_fwd = eqx.filter_vmap(fwd)
+    assert jnp.allclose(
+        vmap_fwd(batch_seq),
+        jnp.stack([fwd(s) for s in batch_seq]),
+    )
+
+    jit_fwd = eqx.filter_jit(fwd)
+    assert jnp.all(jnp.isfinite(jit_fwd(batch_seq[0])))
+
+
+def test_classifier_differentiability(esn_classifier):
+    """Verify gradients flow backward through classify via Equinox."""
+    model = esn_classifier
+    key = jax.random.key(999)
+    seq_len = 20
+
+    res_state = model.driver.default_state()
+    in_seq = jax.random.normal(key, shape=(seq_len, model.data_dim))
+
+    @eqx.filter_value_and_grad
+    def loss_fn(m, x, s):
+        return jnp.sum(m.classify(x, s) ** 2)
+
+    loss, grads = loss_fn(model, in_seq, res_state)
+    assert jnp.isfinite(loss)
+
+    def check_finite(g):
+        if eqx.is_array(g) and jnp.issubdtype(g.dtype, jnp.inexact):
+            assert jnp.all(jnp.isfinite(g))
+
+    jax.tree_util.tree_map(check_finite, grads)

--- a/tests/control/test_control_models.py
+++ b/tests/control/test_control_models.py
@@ -1,3 +1,4 @@
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -365,3 +366,60 @@ def test_train_rccontroller_quadratic(dummy_control_problem_params):
     )
     assert U_controlled.shape == (fcast_len, Nx)
     assert jnp.all(jnp.isfinite(U_controlled))
+
+
+##################### JAX TRANSFORM & AD TESTS #####################
+
+
+@pytest.fixture
+def esn_controller():
+    return orc.control.ESNController(
+        data_dim=3, control_dim=2, res_dim=200, seed=0
+    )
+
+
+def test_controller_transform_stability(esn_controller):
+    """Verify the controller closed-loop is compatible with vmap and jit."""
+    model = esn_controller
+    key = jax.random.key(999)
+    fcast_len = 10
+    batch_size = 3
+
+    control_seq = jax.random.normal(key, shape=(fcast_len, model.control_dim))
+    state_shape = model.driver.default_state().shape
+    batch_state = jax.random.normal(key, shape=(batch_size, *state_shape))
+
+    def fwd(res_state):
+        return model.apply_control(control_seq, res_state)
+
+    vmap_fwd = eqx.filter_vmap(fwd)
+    assert jnp.allclose(
+        vmap_fwd(batch_state),
+        jnp.stack([fwd(s) for s in batch_state]),
+    )
+
+    jit_fwd = eqx.filter_jit(fwd)
+    assert jnp.all(jnp.isfinite(jit_fwd(batch_state[0])))
+
+
+def test_controller_differentiability(esn_controller):
+    """Verify gradients flow backward through apply_control via Equinox."""
+    model = esn_controller
+    key = jax.random.key(999)
+    fcast_len = 10
+
+    control_seq = jax.random.normal(key, shape=(fcast_len, model.control_dim))
+    res_state = jax.random.normal(key, shape=model.driver.default_state().shape)
+
+    @eqx.filter_value_and_grad
+    def loss_fn(m, c, s):
+        return jnp.sum(m.apply_control(c, s))
+
+    loss, grads = loss_fn(model, control_seq, res_state)
+    assert jnp.isfinite(loss)
+
+    def check_finite(g):
+        if eqx.is_array(g) and jnp.issubdtype(g.dtype, jnp.inexact):
+            assert jnp.all(jnp.isfinite(g))
+
+    jax.tree_util.tree_map(check_finite, grads)

--- a/tests/forecaster/test_forecast_models.py
+++ b/tests/forecaster/test_forecast_models.py
@@ -1,4 +1,5 @@
 import diffrax
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -618,3 +619,126 @@ def test_train_rcforecaster_custom_readout():
     # Verify shapes
     assert trained_model.readout.wout.shape == (data_dim, res_dim)
     assert tot_res_seq.shape[1] == res_dim
+
+
+##################### JAX TRANSFORM & AD TESTS #####################
+
+
+@pytest.fixture
+def esn_forecaster():
+    return orc.forecaster.ESNForecaster(data_dim=3, res_dim=200, seed=0)
+
+
+@pytest.fixture
+def ensemble_esn_forecaster():
+    return orc.forecaster.EnsembleESNForecaster(
+        data_dim=3, res_dim=200, chunks=4, seed=0
+    )
+
+
+@pytest.fixture
+def cesn_forecaster():
+    # Fix max_steps and stepsize_controller with diff'ble settings
+    return orc.forecaster.CESNForecaster(
+        data_dim=3,
+        res_dim=200,
+        seed=0,
+        solver=diffrax.Euler(),
+        stepsize_controller=diffrax.ConstantStepSize(),
+        max_steps=4096,
+    )
+
+
+@pytest.mark.parametrize(
+    "forecaster_fixture", ["esn_forecaster", "ensemble_esn_forecaster"]
+)
+def test_forecaster_transform_stability(forecaster_fixture, request):
+    """Verify discrete forecasters are compatible with vmap and jit."""
+    model = request.getfixturevalue(forecaster_fixture)
+    key = jax.random.key(999)
+    fcast_len = 5
+    batch_size = 3
+
+    state_shape = model.driver.default_state().shape
+    batch_state = jax.random.normal(key, shape=(batch_size, *state_shape))
+
+    def fwd(res_state):
+        return model.forecast(fcast_len, res_state)
+
+    vmap_fwd = eqx.filter_vmap(fwd)
+    assert jnp.allclose(
+        vmap_fwd(batch_state),
+        jnp.stack([fwd(s) for s in batch_state]),
+    )
+
+    jit_fwd = eqx.filter_jit(fwd)
+    assert jnp.all(jnp.isfinite(jit_fwd(batch_state[0])))
+
+
+@pytest.mark.parametrize(
+    "forecaster_fixture", ["esn_forecaster", "ensemble_esn_forecaster"]
+)
+def test_forecaster_differentiability(forecaster_fixture, request):
+    """Verify gradients flow backward through forecast via Equinox."""
+    model = request.getfixturevalue(forecaster_fixture)
+    key = jax.random.key(999)
+    fcast_len = 5
+
+    res_state = jax.random.normal(key, shape=model.driver.default_state().shape)
+
+    @eqx.filter_value_and_grad
+    def loss_fn(m, s):
+        return jnp.sum(m.forecast(fcast_len, s))
+
+    loss, grads = loss_fn(model, res_state)
+    assert jnp.isfinite(loss)
+
+    def check_finite(g):
+        if eqx.is_array(g) and jnp.issubdtype(g.dtype, jnp.inexact):
+            assert jnp.all(jnp.isfinite(g))
+
+    jax.tree_util.tree_map(check_finite, grads)
+
+
+def test_cesn_forecast_transform_stability(cesn_forecaster):
+    """Verify CESN continuous forecast is compatible with vmap and jit."""
+    model = cesn_forecaster
+    key = jax.random.key(999)
+    batch_size = 3
+    ts = jnp.arange(5, dtype=jnp.float64) * 0.02
+
+    state_shape = model.driver.default_state().shape
+    batch_state = jax.random.normal(key, shape=(batch_size, *state_shape))
+
+    def fwd(res_state):
+        return model.forecast(ts, res_state)
+
+    vmap_fwd = eqx.filter_vmap(fwd)
+    assert jnp.allclose(
+        vmap_fwd(batch_state),
+        jnp.stack([fwd(s) for s in batch_state]),
+    )
+
+    jit_fwd = eqx.filter_jit(fwd)
+    assert jnp.all(jnp.isfinite(jit_fwd(batch_state[0])))
+
+
+def test_cesn_forecast_differentiability(cesn_forecaster):
+    """Verify gradients flow backward through CESN forecast via Equinox."""
+    model = cesn_forecaster
+    key = jax.random.key(999)
+    ts = jnp.arange(5, dtype=jnp.float64) * 0.02
+
+    res_state = jax.random.normal(key, shape=model.driver.default_state().shape)
+
+    @eqx.filter_value_and_grad
+    def loss_fn(m, s):
+        return jnp.sum(m.forecast(ts, s))
+
+    loss, grads = loss_fn(model, res_state)
+    assert jnp.isfinite(loss)
+
+    def check_finite(g):
+        if eqx.is_array(g) and jnp.issubdtype(g.dtype, jnp.inexact):
+            assert jnp.all(jnp.isfinite(g))
+    jax.tree_util.tree_map(check_finite, grads)

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -1,3 +1,4 @@
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 import pytest
@@ -1071,3 +1072,65 @@ def test_grudriver_consistency_with_equinox_grucell():
 
     # Should be identical
     assert jnp.allclose(driver_output, direct_output)
+
+
+##################### JAX TRANSFORM & AD TESTS #####################
+
+
+@pytest.mark.parametrize(
+    "driver_fixture",
+    ["esndriver", "single_esndriver", "cesn_driver", "taylordriver"],
+)
+def test_driver_transform_stability(driver_fixture, request):
+    """Verify drivers are compatible with vmap and jit."""
+    driver = request.getfixturevalue(driver_fixture)
+    key = jax.random.key(999)
+    batch_size = 3
+
+    if hasattr(driver, "chunks") and driver.chunks > 0:
+        shape = (batch_size, driver.chunks, driver.res_dim)
+    else:
+        shape = (batch_size, driver.res_dim)
+    batch_proj = jax.random.normal(key, shape=shape)
+    batch_state = jax.random.normal(key, shape=shape)
+
+    vmap_advance = eqx.filter_vmap(driver.advance, in_axes=(0, 0))
+    # jax.vmap'ed advance should match the built-in batch_advance
+    assert jnp.allclose(
+        vmap_advance(batch_proj, batch_state),
+        driver.batch_advance(batch_proj, batch_state)
+    )
+
+    jit_advance = eqx.filter_jit(driver.advance)
+    # Explicit external compilation should not leak tracers
+    assert jnp.all(jnp.isfinite(jit_advance(batch_proj[0], batch_state[0])))
+
+
+@pytest.mark.parametrize(
+    "driver_fixture",
+    ["esndriver", "single_esndriver", "cesn_driver", "taylordriver"],
+)
+def test_driver_differentiability(driver_fixture, request):
+    """Verify gradients flow backward through the advance step via Equinox."""
+    driver = request.getfixturevalue(driver_fixture)
+    key = jax.random.key(999)
+
+    if hasattr(driver, "chunks") and driver.chunks > 0:
+        shape = (driver.chunks, driver.res_dim)
+    else:
+        shape = (driver.res_dim,)
+    proj_vars = jax.random.normal(key, shape=shape)
+    res_state = jax.random.normal(key, shape=shape)
+
+    @eqx.filter_value_and_grad
+    def loss_fn(model, p, s):
+        return jnp.sum(model.advance(p, s))
+
+    loss, grads = loss_fn(driver, proj_vars, res_state)
+    assert jnp.isfinite(loss)
+
+    def check_finite(g):
+        if eqx.is_array(g) and jnp.issubdtype(g.dtype, jnp.inexact):
+            assert jnp.all(jnp.isfinite(g))
+
+    jax.tree_util.tree_map(check_finite, grads)

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,3 +1,5 @@
+import equinox as eqx
+import jax
 import jax.numpy as jnp
 import pytest
 
@@ -149,3 +151,86 @@ def test_ensemble_embed_shapes(chunks, batch_size, in_dim):
     inputs = jnp.ones(in_dim)
     outputs = embedding(inputs)
     assert outputs.shape == (chunks, res_dim)
+
+
+##################### JAX TRANSFORM & AD TESTS #####################
+
+
+@pytest.fixture
+def parallel_linearembedding():
+    return orc.embeddings.ParallelLinearEmbedding(
+        in_dim=16,
+        res_dim=64,
+        scaling=0.1,
+        chunks=4,
+        locality=1,
+        dtype=jnp.float64,
+        seed=0,
+    )
+
+
+@pytest.fixture
+def ensemble_linearembedding():
+    return orc.embeddings.EnsembleLinearEmbedding(
+        in_dim=5,
+        res_dim=64,
+        scaling=0.1,
+        chunks=4,
+        dtype=jnp.float64,
+        seed=0,
+    )
+
+
+@pytest.mark.parametrize(
+    "embedding_fixture",
+    [
+        "single_linearembedding",
+        "parallel_linearembedding",
+        "ensemble_linearembedding",
+    ],
+)
+def test_embedding_transform_stability(embedding_fixture, request):
+    """Verify embeddings are compatible with vmap and jit."""
+    embedding = request.getfixturevalue(embedding_fixture)
+    key = jax.random.key(999)
+    batch_size = 3
+
+    batch_in = jax.random.normal(key, shape=(batch_size, embedding.in_dim))
+
+    vmap_embed = eqx.filter_vmap(embedding.embed)
+    assert jnp.allclose(
+        vmap_embed(batch_in),
+        embedding.batch_embed(batch_in),
+    )
+
+    jit_embed = eqx.filter_jit(embedding.embed)
+    assert jnp.all(jnp.isfinite(jit_embed(batch_in[0])))
+
+
+@pytest.mark.parametrize(
+    "embedding_fixture",
+    [
+        "single_linearembedding",
+        "parallel_linearembedding",
+        "ensemble_linearembedding",
+    ],
+)
+def test_embedding_differentiability(embedding_fixture, request):
+    """Verify gradients flow backward through the embed step via Equinox."""
+    embedding = request.getfixturevalue(embedding_fixture)
+    key = jax.random.key(999)
+
+    in_state = jax.random.normal(key, shape=(embedding.in_dim,))
+
+    @eqx.filter_value_and_grad
+    def loss_fn(model, x):
+        return jnp.sum(model.embed(x))
+
+    loss, grads = loss_fn(embedding, in_state)
+    assert jnp.isfinite(loss)
+
+    def check_finite(g):
+        if eqx.is_array(g) and jnp.issubdtype(g.dtype, jnp.inexact):
+            assert jnp.all(jnp.isfinite(g))
+
+    jax.tree_util.tree_map(check_finite, grads)

--- a/tests/test_readouts.py
+++ b/tests/test_readouts.py
@@ -470,3 +470,77 @@ def test_custom_readout_call():
     batch = jnp.ones((5, 10))
     out = readout(batch)
     assert out.shape == (5, 3)
+
+
+##################### JAX TRANSFORM & AD TESTS #####################
+
+# Single-reservoir readouts accept a 1D (res_dim,) state; the parallel/ensemble
+# variants accept a 2D (chunks, res_dim) state. LinearReadout/NonlinearReadout
+# (and QuadraticReadout via NonlinearReadout) are the single-reservoir classes;
+# the Parallel*/Ensemble* classes are their base classes, not instances of them.
+_SINGLE_READOUTS = (orc.readouts.LinearReadout, orc.readouts.NonlinearReadout)
+
+
+def _readout_state_shape(readout):
+    """Per-reservoir-state shape accepted by ``readout.readout``."""
+    if isinstance(readout, _SINGLE_READOUTS):
+        return (readout.res_dim,)
+    return (readout.chunks, readout.res_dim)
+
+
+@pytest.mark.parametrize(
+    "readout_fixture",
+    [
+        "linearreadout",
+        "single_linearreadout",
+        "single_nonlinearreadout",
+        "single_quadraticreadout",
+    ],
+)
+def test_readout_transform_stability(readout_fixture, request):
+    """Verify readouts are compatible with vmap and jit."""
+    readout = request.getfixturevalue(readout_fixture)
+    key = jax.random.key(999)
+    batch_size = 3
+
+    shape = _readout_state_shape(readout)
+    batch_state = jax.random.normal(key, shape=(batch_size, *shape))
+
+    vmap_readout = eqx.filter_vmap(readout.readout)
+    assert jnp.allclose(
+        vmap_readout(batch_state),
+        readout.batch_readout(batch_state),
+    )
+
+    jit_readout = eqx.filter_jit(readout.readout)
+    assert jnp.all(jnp.isfinite(jit_readout(batch_state[0])))
+
+
+@pytest.mark.parametrize(
+    "readout_fixture",
+    [
+        "linearreadout",
+        "single_linearreadout",
+        "single_nonlinearreadout",
+        "single_quadraticreadout",
+    ],
+)
+def test_readout_differentiability(readout_fixture, request):
+    """Verify gradients flow backward through the readout step via Equinox."""
+    readout = request.getfixturevalue(readout_fixture)
+    key = jax.random.key(999)
+
+    res_state = jax.random.normal(key, shape=_readout_state_shape(readout))
+
+    @eqx.filter_value_and_grad
+    def loss_fn(model, s):
+        return jnp.sum(model.readout(s))
+
+    loss, grads = loss_fn(readout, res_state)
+    assert jnp.isfinite(loss)
+
+    def check_finite(g):
+        if eqx.is_array(g) and jnp.issubdtype(g.dtype, jnp.inexact):
+            assert jnp.all(jnp.isfinite(g))
+
+    jax.tree_util.tree_map(check_finite, grads)


### PR DESCRIPTION
As a preface, I want to thank the authors for their hard work and attention to detail in building `OpenReservoirComputing`. This PR supports [the author's JOSS submission](https://github.com/openjournals/joss-reviews/issues/10486#issuecomment-4372361607) by adding dedicated transform and differentiability tests across all core driver architectures.

**Specifically, this PR:**
- Checks that `batch_advance` methods match `jax.vmap` behavior.
- Ensures `jax.jit` compilation executes without leaking tracers.
- Checks that gradient backprop through the PyTree model states via `@eqx.filter_value_and_grad` does not hit non-differentiable operations.

Adding these tests proactively helps verify compatibility with the core JAX composability features that developers may (read: will) naturally expect and rely on when adopting the package.