### PR TITLE
Fix zsh pip install compatibility by quoting extra dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ pip install .
 
 If you would like to use ORC on GPU(s), install the optional GPU dependencies:
 ```bash
-pip install .[gpu]
+pip install ".[gpu]"
 ```
 
 To run the example notebooks, install the optional notebook dependencies:
 ```bash
-pip install .[notebooks]
+pip install ".[notebooks]"
 ```
 
 ## Quick start example
@@ -86,12 +86,12 @@ From the root directory of the repository, create an editable install for your g
 
 CPU:
 ```bash
-pip install -e .[dev]
+pip install -e ".[dev]"
 ```
 
 GPU:
 ```bash
-pip install -e .[dev, gpu]
+pip install -e ".[dev, gpu]"
 ```
 
 The main branch is protected from direct changes. If you would like to make a change please create a new branch and work on your new feature. After you are satisfied with your changes, please run our testing suite to ensure all is working well. We also expect new tests to be written for all changes if additions are made. The tests can be simply run from the root directory of the repository with

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -18,7 +18,7 @@ We welcome contributions to the OpenReservoirComputing project! This guide will 
 
 3. **Install in development mode**:
    ```bash
-   pip install -e .[dev,notebooks,gpu]
+   pip install -e ".[dev,notebooks,gpu]"
    ```
 
 ## Code Style

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -25,7 +25,7 @@ For GPU acceleration with CUDA support:
 ```bash
 git clone https://github.com/Jan-Williams/OpenReservoirComputing.git
 cd OpenReservoirComputing
-pip install .[gpu]
+pip install ".[gpu]"
 ```
 
 
@@ -36,7 +36,7 @@ For contributors or advanced users who want to modify the code:
 ```bash
 git clone https://github.com/Jan-Williams/OpenReservoirComputing.git
 cd OpenReservoirComputing
-pip install -e .[dev]
+pip install -e ".[dev]"
 ```
 
 This includes additional tools for testing, formatting, and documentation.
@@ -46,7 +46,7 @@ This includes additional tools for testing, formatting, and documentation.
 To install all optional dependencies (GPU, development, notebooks, documentation):
 
 ```bash
-pip install -e .[all]
+pip install -e ".[all]"
 ```
 
 ## Verification


### PR DESCRIPTION
As a preface, I want to thank the authors for their hard work and attention to detail in building `OpenReservoirComputing`. This PR supports [the author's JOSS submission](https://github.com/openjournals/joss-reviews/issues/10486#issuecomment-4372361607) by intoroducing a small but meaningful QoL improvement for users operating in zsh environments (the default on modern macOS).

**The Issue:** 
Unquoted square brackets (e.g., `pip install .[notebooks]`) trigger glob matching in zsh by default, causing the command to fail.

**The Fix:**
Wrap all extra-dependency installation commands in double quotes (e.g., `pip install ".[notebooks]"`) across the README and documentation files.
