### PR TITLE
Float64update

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,30 +13,20 @@ ORC is the one-stop-shop for performant reservoir computing in jax. Key high-lev
 
 ## Installation
 
-To install ORC, first clone the repository onto your local machine
+The easiest way to get started with ORC is to install from PyPI:
 ```bash
-git clone https://github.com/Jan-Williams/OpenReservoirComputing.git
+pip install OpenReservoirComputing
 ```
 
-Then navigate to the cloned directory and use `pip` to install:
-```bash
-pip install .
-```
-
-If you would like to use ORC on GPU(s), install the optional GPU dependencies:
-```bash
-pip install ".[gpu]"
-```
-
-To run the example notebooks, install the optional notebook dependencies:
-```bash
-pip install ".[notebooks]"
-```
+If you're interested in the latest, unreleased version or in contributing, you can install from source. Please see the Contribution guidelines below for more details. 
 
 ## Quick start example
 Below is a minimal quick-start example to train your first RC with ORC. It leverages the built-in data library to integrate the Lorenz63 ODE before training and forecasting with ORC.
 
 ```python
+import jax
+# ORC models often perform much better with float64 enabled
+jax.config.update("jax_enable_x64", True)
 import orc
 
 # integrate the Lorenz system 

--- a/examples/classification.ipynb
+++ b/examples/classification.ipynb
@@ -19,12 +19,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "c3d4e5f6",
    "metadata": {},
    "outputs": [],
    "source": [
     "import jax\n",
+    "jax.config.update(\"jax_enable_x64\", True)\n",
     "import jax.numpy as jnp\n",
     "import equinox as eqx\n",
     "import matplotlib.pyplot as plt\n",
@@ -402,7 +403,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "orc2",
+   "display_name": "joss_orc",
    "language": "python",
    "name": "python3"
   },
@@ -416,7 +417,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.12"
+   "version": "3.13.13"
   }
  },
  "nbformat": 4,

--- a/examples/continuous_rc.ipynb
+++ b/examples/continuous_rc.ipynb
@@ -18,18 +18,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "b0199e4a",
    "metadata": {},
    "outputs": [],
    "source": [
     "import jax\n",
+    "jax.config.update(\"jax_enable_x64\", True)\n",
     "import jax.numpy as jnp\n",
     "import diffrax\n",
     "import equinox as eqx\n",
     "from jaxtyping import Array, Float\n",
     "\n",
-    "jax.config.update(\"jax_enable_x64\", True)\n",
     "import orc\n",
     "import orc.utils.visualization as vis"
    ]

--- a/examples/control.ipynb
+++ b/examples/control.ipynb
@@ -18,14 +18,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "ca4cf946",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import orc\n",
     "import jax\n",
+    "jax.config.update(\"jax_enable_x64\", True)\n",
     "import jax.numpy as jnp\n",
+    "import orc\n",
     "import matplotlib.pyplot as plt"
    ]
   },

--- a/examples/data_library.ipynb
+++ b/examples/data_library.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "99550260",
    "metadata": {},
    "outputs": [],
@@ -21,6 +21,7 @@
     "import time\n",
     "\n",
     "import jax\n",
+    "jax.config.update(\"jax_enable_x64\", True)\n",
     "import jax.numpy as jnp\n",
     "import jax.random\n",
     "import diffrax\n",
@@ -28,9 +29,7 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "import orc.data\n",
-    "import orc.utils.visualization as vis\n",
-    "\n",
-    "jax.config.update(\"jax_enable_x64\", True)"
+    "import orc.utils.visualization as vis"
    ]
   },
   {

--- a/examples/ks.ipynb
+++ b/examples/ks.ipynb
@@ -10,11 +10,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import jax\n",
+    "jax.config.update(\"jax_enable_x64\", True)\n",
     "import jax.numpy as jnp\n",
     "import orc"
    ]

--- a/examples/lorenz.ipynb
+++ b/examples/lorenz.ipynb
@@ -19,12 +19,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "4a6163bd",
    "metadata": {},
    "outputs": [],
    "source": [
     "import jax\n",
+    "jax.config.update(\"jax_enable_x64\", True)\n",
     "import jax.numpy as jnp\n",
     "import orc"
    ]

--- a/examples/rc_background.ipynb
+++ b/examples/rc_background.ipynb
@@ -56,13 +56,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "# imports\n",
-    "import equinox as eqx\n",
     "import jax\n",
+    "jax.config.update(\"jax_enable_x64\", True)\n",
+    "import equinox as eqx\n",
     "import jax.numpy as jnp\n",
     "\n",
     "import orc\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ select = ["E", "W", "F", "D", "UP", "B", "A", "C4", "N", "SIM", "I"]
 ignore = ["N806", "N802", "N803"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["D"]
+"tests/*" = ["D", "E402"]
 "docs/*.py" = ["D", "A"]
 "setup.py" = ["D"]
 "*.ipynb" = ["E", "W", "F", "D", "UP", "B", "A", "C4", "N", "SIM", "I"]

--- a/src/orc/__init__.py
+++ b/src/orc/__init__.py
@@ -1,4 +1,6 @@
-"""Components of models. Setting x64 on import."""
+"""Components of models."""
+
+import warnings
 
 import jax
 
@@ -13,7 +15,13 @@ from orc import (
     utils,
 )
 
-jax.config.update("jax_enable_x64", True)
+if not jax.config.jax_enable_x64:
+    warnings.warn(
+        "orc requires float64 precision. Enable it before importing orc with: "
+        "jax.config.update('jax_enable_x64', True)",
+        UserWarning,
+        stacklevel=2,
+    )
 
 __all__ = [
     "forecaster",

--- a/src/orc/__init__.py
+++ b/src/orc/__init__.py
@@ -17,7 +17,8 @@ from orc import (
 
 if not jax.config.jax_enable_x64:
     warnings.warn(
-        "orc requires float64 precision. Enable it before importing orc with: "
+        "For good performance, orc often requires float64 precision. Enable it " \
+        "before importing orc with: "
         "jax.config.update('jax_enable_x64', True)",
         UserWarning,
         stacklevel=2,

--- a/src/orc/classifier/models.py
+++ b/src/orc/classifier/models.py
@@ -9,7 +9,6 @@ from orc.embeddings import LinearEmbedding
 from orc.readouts import LinearReadout, QuadraticReadout
 
 
-
 class ESNClassifier(RCClassifierBase):
     """
     Basic implementation of ESN for classification tasks.

--- a/src/orc/classifier/models.py
+++ b/src/orc/classifier/models.py
@@ -8,7 +8,6 @@ from orc.drivers import ESNDriver
 from orc.embeddings import LinearEmbedding
 from orc.readouts import LinearReadout, QuadraticReadout
 
-jax.config.update("jax_enable_x64", True)
 
 
 class ESNClassifier(RCClassifierBase):

--- a/src/orc/control/models.py
+++ b/src/orc/control/models.py
@@ -9,7 +9,6 @@ from orc.embeddings import LinearEmbedding
 from orc.readouts import LinearReadout, QuadraticReadout
 
 
-
 class ESNController(RCControllerBase):
     """
     Basic implementation of ESN for control tasks.

--- a/src/orc/control/models.py
+++ b/src/orc/control/models.py
@@ -8,7 +8,6 @@ from orc.drivers import ESNDriver
 from orc.embeddings import LinearEmbedding
 from orc.readouts import LinearReadout, QuadraticReadout
 
-jax.config.update("jax_enable_x64", True)
 
 
 class ESNController(RCControllerBase):

--- a/src/orc/data/integrators.py
+++ b/src/orc/data/integrators.py
@@ -8,7 +8,6 @@ import jax.numpy as jnp
 from jaxtyping import Array, Float
 
 
-
 # TODO: typing
 ######################## Basic Chaotic ODEs ########################
 @jax.jit

--- a/src/orc/data/integrators.py
+++ b/src/orc/data/integrators.py
@@ -7,7 +7,6 @@ import jax
 import jax.numpy as jnp
 from jaxtyping import Array, Float
 
-jax.config.update("jax_enable_x64", True)
 
 
 # TODO: typing

--- a/src/orc/drivers.py
+++ b/src/orc/drivers.py
@@ -12,7 +12,6 @@ from jaxtyping import Array, Float
 
 from orc.utils import max_eig_arnoldi
 
-jax.config.update("jax_enable_x64", True)
 
 
 class DriverBase(eqx.Module, ABC):

--- a/src/orc/drivers.py
+++ b/src/orc/drivers.py
@@ -13,7 +13,6 @@ from jaxtyping import Array, Float
 from orc.utils import max_eig_arnoldi
 
 
-
 class DriverBase(eqx.Module, ABC):
     """
     Base class dictating API for all implemented reservoir drivers.

--- a/src/orc/embeddings.py
+++ b/src/orc/embeddings.py
@@ -7,7 +7,6 @@ import jax
 import jax.numpy as jnp
 from jaxtyping import Array, Float
 
-jax.config.update("jax_enable_x64", True)
 
 
 class EmbedBase(eqx.Module, ABC):

--- a/src/orc/embeddings.py
+++ b/src/orc/embeddings.py
@@ -8,7 +8,6 @@ import jax.numpy as jnp
 from jaxtyping import Array, Float
 
 
-
 class EmbedBase(eqx.Module, ABC):
     """
     Base class dictating API for all implemented embedding layers.

--- a/src/orc/forecaster/models.py
+++ b/src/orc/forecaster/models.py
@@ -14,7 +14,6 @@ from orc.readouts import (
 )
 
 
-
 class ESNForecaster(RCForecasterBase):
     """
     Basic implementation of ESN for forecasting.

--- a/src/orc/forecaster/models.py
+++ b/src/orc/forecaster/models.py
@@ -13,7 +13,6 @@ from orc.readouts import (
     ParallelQuadraticReadout,
 )
 
-jax.config.update("jax_enable_x64", True)
 
 
 class ESNForecaster(RCForecasterBase):

--- a/tests/classifier/test_classifier_models.py
+++ b/tests/classifier/test_classifier_models.py
@@ -3,6 +3,8 @@ import jax
 import jax.numpy as jnp
 import pytest
 
+jax.config.update("jax_enable_x64", True)
+
 import orc
 import orc.classifier
 

--- a/tests/control/test_control_models.py
+++ b/tests/control/test_control_models.py
@@ -4,6 +4,8 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
+jax.config.update("jax_enable_x64", True)
+
 import orc
 import orc.control
 import orc.data

--- a/tests/data/test_integrators.py
+++ b/tests/data/test_integrators.py
@@ -2,6 +2,8 @@ import diffrax
 import jax
 import jax.numpy as jnp
 
+jax.config.update("jax_enable_x64", True)
+
 import orc
 import orc.data
 

--- a/tests/forecaster/test_forecast_models.py
+++ b/tests/forecaster/test_forecast_models.py
@@ -5,6 +5,8 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
+jax.config.update("jax_enable_x64", True)
+
 import orc
 import orc.data
 

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -4,6 +4,8 @@ import jax.numpy as jnp
 import pytest
 from jax.experimental import sparse
 
+jax.config.update("jax_enable_x64", True)
+
 import orc
 
 ##################### ESN TESTS #####################

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -3,6 +3,8 @@ import jax
 import jax.numpy as jnp
 import pytest
 
+jax.config.update("jax_enable_x64", True)
+
 import orc
 
 

--- a/tests/test_readouts.py
+++ b/tests/test_readouts.py
@@ -3,6 +3,8 @@ import jax
 import jax.numpy as jnp
 import pytest
 
+jax.config.update("jax_enable_x64", True)
+
 import orc
 
 

--- a/tests/utils/test_numerics.py
+++ b/tests/utils/test_numerics.py
@@ -3,6 +3,8 @@ import jax.experimental.sparse
 import jax.numpy as jnp
 import pytest
 
+jax.config.update("jax_enable_x64", True)
+
 from orc.utils import max_eig_arnoldi
 
 # Tolerance for numerical comparisons

--- a/tests/utils/test_regressions.py
+++ b/tests/utils/test_regressions.py
@@ -2,6 +2,8 @@ import jax
 import jax.numpy as jnp
 import pytest
 
+jax.config.update("jax_enable_x64", True)
+
 from orc.utils.regressions import (
     _solve_all_ridge_reg,
     _solve_all_ridge_reg_batched,

--- a/tests/utils/test_visualization.py
+++ b/tests/utils/test_visualization.py
@@ -1,8 +1,11 @@
 from unittest.mock import patch
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
+
+jax.config.update("jax_enable_x64", True)
 
 from orc.utils import visualization as vis
 


### PR DESCRIPTION
Opening this PR in response to Issues #58 (default enabling of float64) and #57 (installation instructions) raised by @ymahlau. 

ORC no longer enables float64 by default, but does raise a warning if imported and float64 is not enabled. In many applications, I've found the difference in float64 vs float32 performance to be striking. Raising a warning seems a good middle ground between forcing float64 and having the recommendation of float64 in documentation alone. 

Additionally, the README.md has been updated to provide instructions to install from PyPI as well as source.

https://github.com/openjournals/joss-reviews/issues/10486